### PR TITLE
Add CSRF token implementation.

### DIFF
--- a/rust-server/Cargo.lock
+++ b/rust-server/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "actix-session",
  "actix-web",
  "base32",
+ "base64 0.21.0",
  "chrono",
  "diesel",
  "diesel_migrations",

--- a/rust-server/Cargo.toml
+++ b/rust-server/Cargo.toml
@@ -25,3 +25,4 @@ actix-session = { version = "0.7.2", features = ["redis-rs-session", "redis-rs-t
 time = "0.3.20"
 actix-governor = "0.4.0"
 diesel_migrations = "2.0.0"
+base64 = "0.21.0"

--- a/rust-server/src/config.rs
+++ b/rust-server/src/config.rs
@@ -5,6 +5,9 @@ pub const ACCESS_TOKEN_TIME_SECONDS: i64 = 60 * 15; // 15 minutes
 pub const REFRESH_TOKEN_TIME_SECONDS: i64 = 60 * 60 * 24; // 1 day
 pub const AUTH_COOKIE_NAME: &str = "access_token";
 pub const REFRESH_COOKIE_NAME: &str = "refresh_token";
+pub const CSRF_COOKIE_NAME: &str = "csrf_token";
+pub const CSRF_HEADER_NAME: &str = "csrf-token";
+pub const CSRF_TOKEN_BYTES: usize = 20;
 
 const DATABASE_URL_ENV_NAME: &str = "DATABASE_URL";
 const REDIS_URL_ENV_NAME: &str = "REDIS_URL";

--- a/rust-server/src/handlers.rs
+++ b/rust-server/src/handlers.rs
@@ -1,2 +1,4 @@
 pub mod authentication;
 pub mod passwords;
+#[cfg(test)]
+mod tests;

--- a/rust-server/src/handlers/passwords.rs
+++ b/rust-server/src/handlers/passwords.rs
@@ -178,6 +178,8 @@ mod tests {
 
     const SECRET: &str = "1qGpT9oS0dChQ287Ve1Uyha6CRG3nqGI";
 
+    use super::super::tests::test_utils::{CSRF_TOKEN_HEADER, TEST_CSRF_TOKEN};
+
     async fn generate_response(
         user_repository_data: web::Data<dyn UserRepository>,
         stored_password_repository: web::Data<dyn StoredPasswordRepository>,
@@ -206,7 +208,7 @@ mod tests {
 
     fn build_auth_cookie<'a>() -> Cookie<'a> {
         let encoding_key = EncodingKey::from_secret(SECRET.as_bytes());
-        let auth_token = generate_access_token(1, &encoding_key).unwrap();
+        let auth_token = generate_access_token(1, TEST_CSRF_TOKEN, &encoding_key).unwrap();
         Cookie::build(AUTH_COOKIE_NAME, auth_token)
             .http_only(true)
             .finish()
@@ -372,6 +374,7 @@ mod tests {
 
         let req = test::TestRequest::get()
             .uri("/is_master_password_set")
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -395,6 +398,7 @@ mod tests {
 
         let req = test::TestRequest::get()
             .uri("/is_master_password_set")
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -420,6 +424,7 @@ mod tests {
             .set_json(json!({
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -441,6 +446,7 @@ mod tests {
             .set_json(json!({
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -463,6 +469,7 @@ mod tests {
             .set_json(json!({
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -485,6 +492,7 @@ mod tests {
             .set_json(json!({
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -524,6 +532,7 @@ mod tests {
 
         let req = test::TestRequest::get()
             .uri("/")
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -550,6 +559,7 @@ mod tests {
                 "purpose": "Test",
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -583,6 +593,7 @@ mod tests {
                 "purpose": "Test",
                 "password": "123456"
             }))
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =
@@ -605,6 +616,7 @@ mod tests {
 
         let req = test::TestRequest::delete()
             .uri("/password/1")
+            .insert_header(CSRF_TOKEN_HEADER)
             .cookie(build_auth_cookie());
 
         let resp =

--- a/rust-server/src/handlers/tests.rs
+++ b/rust-server/src/handlers/tests.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+pub mod test_utils {
+    use crate::config::CSRF_HEADER_NAME;
+
+    pub const TEST_CSRF_TOKEN: &str = "abcdefghijklmnop";
+    pub const CSRF_TOKEN_HEADER: (&str, &str) = (CSRF_HEADER_NAME, TEST_CSRF_TOKEN);
+}

--- a/rust-server/src/main.rs
+++ b/rust-server/src/main.rs
@@ -1,4 +1,3 @@
-use actix_cors::Cors;
 use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_session::{config::PersistentSession, storage::RedisSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, web, App, HttpServer};
@@ -68,7 +67,6 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(decoding_key.clone()))
             .app_data(user_repository_data.clone())
             .app_data(stored_password_repository_data.clone())
-            .wrap(Cors::permissive()) // TODO, change this
             .service(
                 web::scope("/api")
                     .service(

--- a/rust-server/src/utils.rs
+++ b/rust-server/src/utils.rs
@@ -1,2 +1,3 @@
+pub mod csrf_utils;
 pub mod jwt_utils;
 pub mod totp_utils;

--- a/rust-server/src/utils/csrf_utils.rs
+++ b/rust-server/src/utils/csrf_utils.rs
@@ -1,0 +1,11 @@
+use crate::config::CSRF_TOKEN_BYTES;
+use base64::{engine::general_purpose, Engine as _};
+use rand::Rng;
+
+pub fn generate_csrf_token() -> String {
+    let mut secret_bytes = [0u8; CSRF_TOKEN_BYTES];
+    let mut rng = rand::thread_rng();
+    rng.fill(&mut secret_bytes[..]);
+
+    general_purpose::STANDARD.encode(&secret_bytes)
+}


### PR DESCRIPTION
CSRF token is implemented using double submit through jwt token and HTTP header.

Also changed CORS and cookie policies in rust-server

